### PR TITLE
Create New Admins Model

### DIFF
--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,0 +1,11 @@
+class Admin < ApplicationRecord
+  validates(
+    :email,
+    format: {with: URI::MailTo::EMAIL_REGEXP},
+    presence: true,
+    uniqueness: true
+  )
+
+  validates :first_name, length: {minimum: 3, maximum: 16}, presence: true
+  validates :last_name, length: {minimum: 3, maximum: 32}, presence: true
+end

--- a/db/migrate/20251230145721_create_admins.rb
+++ b/db/migrate/20251230145721_create_admins.rb
@@ -1,0 +1,10 @@
+class CreateAdmins < ActiveRecord::Migration[8.1]
+  def change
+    create_table :admins do |t|
+      t.string :email, null: false
+      t.string :first_name, null: false
+      t.string :last_name, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_12_11_102202) do
+ActiveRecord::Schema[8.1].define(version: 2025_12_30_145721) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "admins", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "email", null: false
+    t.string "first_name", null: false
+    t.string "last_name", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "group_people", force: :cascade do |t|
     t.datetime "created_at", null: false

--- a/spec/factories/admin_factory.rb
+++ b/spec/factories/admin_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :admin do
+    sequence(:email) { "adminperson-#{it}@example.com" }
+    sequence(:first_name) { "Adminperson" }
+    sequence(:last_name) { "Employeeperson" }
+  end
+end

--- a/spec/models/admin_spec.rb
+++ b/spec/models/admin_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe(Admin, type: :model) do
+  subject { build(:admin) }
+
+  it do
+    is_expected.to(
+      allow_values("admin@example.com", "test.name@sub.domain.example.org")
+        .for(:email)
+    )
+
+    is_expected.not_to(
+      allow_values("admin", "@example.com", "example.net", "test@example.")
+        .for(:email)
+    )
+  end
+
+  it { is_expected.to(validate_presence_of(:email)) }
+  it { is_expected.to(validate_uniqueness_of(:email)) }
+
+  it do
+    is_expected.to(
+      validate_length_of(:first_name).is_at_least(3).is_at_most(16)
+    )
+  end
+
+  it { is_expected.to(validate_presence_of(:first_name)) }
+
+  it do
+    is_expected.to(validate_length_of(:last_name).is_at_least(3).is_at_most(32))
+  end
+
+  it { is_expected.to(validate_presence_of(:last_name)) }
+
+  it "has a valid factory" do
+    expect(build(:admin)).to(be_valid)
+  end
+end


### PR DESCRIPTION
We need a database table to store information on who can make changes to the app data. This is stored in an `admins` table.

This changeset introduces the `Admin` model and its tests and migration.

Issue: #28