### PR TITLE
Update Brakeman

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ group :development do
 end
 
 group :development, :test do
-  gem "brakeman", require: false # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
+  gem "brakeman", "~> 8.0.2", require: false
   gem "bundler-audit", require: false # Audits gems for known security defects (use config/bundler-audit.yml to ignore issues)
   gem "capybara", "~> 3.40"
   gem "debug", platforms: %i[mri windows], require: "debug/prelude" # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.21.1)
       msgpack (~> 1.2)
-    brakeman (7.1.2)
+    brakeman (8.0.2)
       racc
     builder (3.3.0)
     bundler-audit (0.9.3)
@@ -409,7 +409,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (~> 1.21.1)
-  brakeman
+  brakeman (~> 8.0.2)
   bundler-audit
   capybara (~> 3.40)
   debug


### PR DESCRIPTION
CI was failing due to too low a major version of `brakeman`.

This changeset updates it to the latest version.

GH #57