### PR TITLE
Add CRUD UI and Tests for Organization

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -4,4 +4,19 @@
   .btn-primary {
     @apply inline-block px-4 py-2 rounded-lg bg-green-600 text-white font-medium no-underline hover:bg-green-700 transition-colors;
   }
+
+  .input-primary {
+    @apply block w-full min-w-[16rem] px-4 py-2.5 text-base text-slate-800 bg-white border border-slate-300 rounded-lg shadow-sm
+           placeholder-slate-400
+           focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500
+           disabled:bg-slate-100 disabled:text-slate-500;
+  }
+
+  .flash-notice {
+    @apply bg-green-50 border-green-200 text-green-800;
+  }
+
+  .flash-alert {
+    @apply bg-red-50 border-red-200 text-red-800;
+  }
 }

--- a/app/controllers/manage/organizations_controller.rb
+++ b/app/controllers/manage/organizations_controller.rb
@@ -3,7 +3,10 @@ class Manage::OrganizationsController < Manage::ManageController
     @organization = Organization.new(organization_params)
 
     if @organization.save
-      redirect_to manage_organization_path(@organization), notice: "Organization created successfully"
+      redirect_to(
+        manage_organizations_path,
+        notice: "Organization created successfully"
+      )
     else
       render :new
     end
@@ -13,9 +16,15 @@ class Manage::OrganizationsController < Manage::ManageController
     @organization = Organization.find(params[:id])
 
     if @organization.destroy
-      redirect_to manage_organizations_path, notice: "Organization deleted successfully"
+      redirect_to(
+        manage_organizations_path,
+        notice: "Organization deleted successfully"
+      )
     else
-      redirect_to manage_organizations_path, alert: "Failed to delete organization"
+      redirect_to(
+        manage_organizations_path,
+        alert: "Failed to delete organization"
+      )
     end
   end
 
@@ -31,15 +40,14 @@ class Manage::OrganizationsController < Manage::ManageController
     @organization = Organization.new
   end
 
-  def show
-    @organization = Organization.find(params[:id])
-  end
-
   def update
     @organization = Organization.find(params[:id])
 
     if @organization.update(organization_params)
-      redirect_to manage_organization_path(@organization), notice: "Organization updated successfully"
+      redirect_to(
+        manage_organizations_path,
+        notice: "Organization updated successfully"
+      )
     else
       render :edit
     end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -2,4 +2,6 @@ class Organization < ApplicationRecord
   has_many :groups, dependent: :destroy, inverse_of: :organization
   has_many :organization_people, dependent: :destroy, inverse_of: :organization
   has_many :people, through: :organization_people
+
+  validates(:name, presence: true, length: {minimum: 3})
 end

--- a/app/views/layouts/manage/managelayout.html.erb
+++ b/app/views/layouts/manage/managelayout.html.erb
@@ -26,14 +26,27 @@
   <body>
     <nav class="fixed top-0 left-0 right-0 z-10 bg-slate-800 text-white shadow-md">
       <div class="container mx-auto px-5 flex items-center h-14">
-        <%= link_to "Fellowship Dashboard", manage_root_path, class: "font-semibold text-lg hover:text-slate-200" %>
+        <%= link_to(
+          "Fellowship Dashboard",
+          manage_root_path,
+          class: "font-semibold text-lg hover:text-slate-200"
+        ) %>
         <div class="ml-8 flex gap-6">
-          <%= link_to "Organizations", manage_organizations_path, class: "hover:text-slate-200" %>
+          <%= link_to(
+            "Organizations",
+            manage_organizations_path,
+            class: "hover:text-slate-200"
+          ) %>
         </div>
       </div>
     </nav>
+
     <main class="container mx-auto mt-20 px-5 flex pt-4">
       <%= yield %>
     </main>
+
+    <div class="container mx-auto mt-20 px-20 flex">
+      <%= render "manage/flash_messages" %>
+    <div>
   </body>
 </html>

--- a/app/views/manage/_flash_messages.html.erb
+++ b/app/views/manage/_flash_messages.html.erb
@@ -1,0 +1,9 @@
+<% if flash.any? %>
+  <div class="mb-6 space-y-3">
+    <% flash.each do |type, message| %>
+      <div class="flash-message flash-<%= type %> px-4 py-3 rounded-lg border shadow-sm">
+        <%= message %>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/manage/organizations/_form.html.erb
+++ b/app/views/manage/organizations/_form.html.erb
@@ -1,0 +1,43 @@
+<%=
+  form_with(
+    data: { turbo: false },
+    model: form_model,
+    url: form_path
+  ) do |form|
+%>
+  <% if form_model.errors.any? %>
+    <div class="mb-6 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
+      <p class="mb-2 font-semibold">
+        <%= pluralize(form_model.errors.count, "error") %> prevented this organization from being saved:
+      </p>
+      <ul class="list-disc list-inside space-y-1">
+        <% form_model.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="mt-4 flex items-center gap-3">
+    <%= form.label(
+      :name,
+      class: "text-sm font-medium text-slate-700 shrink-0 min-w-[4rem]"
+    ) %>
+    <div class="flex-1 min-w-0">
+      <%= form.text_field(
+        :name,
+        class: "input-primary w-full",
+        placeholder: "Organization name"
+      ) %>
+      <% if form_model.errors[:name].any? %>
+        <p class="mt-1 text-sm text-red-600">
+          <%= form_model.errors[:name].first %>
+        </p>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="mt-16">
+    <%= form.submit "💾 Save", class: "btn-primary" %>
+  </div>
+<% end %>

--- a/app/views/manage/organizations/edit.html.erb
+++ b/app/views/manage/organizations/edit.html.erb
@@ -1,0 +1,17 @@
+<div>
+  <div class="mb-8">
+    <h1 class="text-2xl font-bold">Edit Organization</h1>
+  </div>
+
+  <div>
+    <%=
+      render(
+        partial: "form",
+        locals: {
+          form_path: manage_organization_path(@organization),
+          form_model: @organization
+        }
+      )
+    %>
+  </div>
+</div>

--- a/app/views/manage/organizations/index.html.erb
+++ b/app/views/manage/organizations/index.html.erb
@@ -13,7 +13,7 @@
     </span>
   </div>
 
-  <table class="table-auto">
+  <table class="table-auto border-separate border-spacing-y-2">
     <thead>
       <tr>
         <th>Name</th>
@@ -25,7 +25,10 @@
     </thead>
     <tbody>
       <% @organizations.each do |organization| %>
-        <tr id="manage-organization-row-<%= organization.id %>" class="hover:bg-slate-100">
+        <tr
+          id="manage-organization-row-<%= organization.id %>"
+          class="hover:bg-slate-100"
+        >
           <td class="pr-4 py-2"><%= organization.name %></td>
           <td class="px-4 py-2"><%= organization.id %></td>
           <td class="px-4 py-2">
@@ -41,13 +44,16 @@
               class: "btn-primary px-4 py-2"
             ) %>
 
-            <%= link_to(
+            <%= button_to(
               "🗑️ Delete",
               manage_organization_path(organization),
               method: :delete,
               class: "btn-primary px-4 py-2",
-              data: {
-                confirm: "Are you sure you want to delete this organization?"
+              form_class: "inline-block ml-2",
+              form: {
+                data: {
+                  turbo_confirm: "Are you sure you want to delete this organization?"
+                }
               }
             ) %>
           </td>

--- a/app/views/manage/organizations/new.html.erb
+++ b/app/views/manage/organizations/new.html.erb
@@ -1,0 +1,17 @@
+<div>
+  <div class="mb-8">
+    <h1 class="text-2xl font-bold">New Organization</h1>
+  </div>
+
+  <div>
+    <%=
+      render(
+        partial: "form",
+        locals: {
+          form_path: manage_organizations_path(),
+          form_model: @organization
+        }
+      )
+    %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,4 @@
 Rails.application.routes.draw do
-  resources :organizations
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", :as => :rails_health_check
 
   # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
@@ -14,7 +9,8 @@ Rails.application.routes.draw do
   # root "posts#index"
 
   namespace(:manage) do
-    resources(:organizations)
+    resources(:organizations, except: [:show])
+
     root(controller: :dashboards, action: :index)
   end
 

--- a/spec/features/manage/organizations/admin_creates_organization_spec.rb
+++ b/spec/features/manage/organizations/admin_creates_organization_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.feature("An Admin Views New Organization Page", type: :feature) do
+  scenario "Creates an Organization with Success" do
+    visit new_manage_organization_path
+
+    fill_in("Name", with: "Prophets of the Promise")
+
+    click_button("💾 Save")
+
+    expect(page).to have_content("Organization created successfully")
+  end
+
+  scenario "Sees an Error when Creating an Organization Fails" do
+    visit new_manage_organization_path
+
+    fill_in("Name", with: "🧇")
+
+    click_button("💾 Save")
+
+    expect(page).to have_content("")
+  end
+end

--- a/spec/features/manage/organizations/admin_edits_organization_spec.rb
+++ b/spec/features/manage/organizations/admin_edits_organization_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.feature("An Admin Views New Organization Page", type: :feature) do
+  scenario "Creates an Organization with Success" do
+    organization = create(:organization, name: "Discipled Discerners")
+
+    visit edit_manage_organization_path(organization)
+
+    fill_in("Name", with: "Discipled Discerners!")
+
+    click_button("💾 Save")
+
+    expect(page).to have_content("Organization updated successfully")
+  end
+
+  scenario "Sees an Error when Creating an Organization Fails" do
+    organization = create(:organization, name: "Namers of the Name")
+
+    visit edit_manage_organization_path(organization)
+
+    fill_in("Name", with: "!?")
+
+    click_button("💾 Save")
+
+    expect(page).to(
+      have_content("error prevented this organization from being saved")
+    )
+  end
+end

--- a/spec/features/manage/organizations/admin_views_organizations_index_spec.rb
+++ b/spec/features/manage/organizations/admin_views_organizations_index_spec.rb
@@ -13,13 +13,42 @@ RSpec.feature("An Admin Views Organizations Index Page", type: :feature) do
     within("#manage-organization-row-#{organization_a.id}") do
       expect(page).to have_content("Mighty Men of Manessah")
       expect(page).to have_link("✍️ Edit")
-      expect(page).to have_link("🗑️ Delete")
+      expect(page).to have_button("🗑️ Delete")
     end
 
     within("#manage-organization-row-#{organization_b.id}") do
       expect(page).to have_content("Herders of Bashan")
       expect(page).to have_link("✍️ Edit")
-      expect(page).to have_link("🗑️ Delete")
+      expect(page).to have_button("🗑️ Delete")
     end
+  end
+
+  scenario "Navigate to New Organization" do
+    visit manage_organizations_url
+
+    click_link("⛪ New Organization")
+
+    expect(page.current_path).to eq(new_manage_organization_path)
+  end
+
+  scenario "Navigating to Edit Organization" do
+    organization = create(:organization)
+
+    visit manage_organizations_url
+
+    click_link("Edit")
+
+    expect(page.current_path).to eq(edit_manage_organization_path(organization))
+  end
+
+  scenario "Delete an Organization" do
+    create(:organization, name: "Edomite Exalters")
+
+    visit manage_organizations_url
+
+    click_button("🗑️ Delete")
+
+    expect(page).to have_content("Organization deleted successfully")
+    expect(page).not_to have_content("Edomite Exalters")
   end
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -22,4 +22,12 @@ RSpec.describe(Organization, type: :model) do
   it "has a valid factory" do
     expect(build(:organization)).to(be_valid)
   end
+
+  it do
+    is_expected.to(validate_presence_of(:name))
+  end
+
+  it do
+    is_expected.to(validate_length_of(:name))
+  end
 end


### PR DESCRIPTION
We want an interface to help inspire some design and UX for the /manage tools.

This changeset adds the Organizations UI, and it adds style and features to help build the tools that manage other models (Groups, etc).

GH: #62