### PR TITLE
Add People CRUD UI

### DIFF
--- a/app/controllers/manage/people_controller.rb
+++ b/app/controllers/manage/people_controller.rb
@@ -1,0 +1,51 @@
+class Manage::PeopleController < Manage::ManageController
+  def create
+    @person = Person.new(person_params)
+
+    if @person.save
+      redirect_to(manage_people_path, notice: "Person created successfully")
+    else
+      render :new
+    end
+  end
+
+  def destroy
+    @person = Person.find(params[:id])
+
+    if @person.destroy
+      redirect_to(manage_people_path, notice: "Person deleted successfully")
+    else
+      redirect_to(manage_people_path, alert: "Failed to delete Person")
+    end
+  end
+
+  def edit
+    @person = Person.find(params[:id])
+  end
+
+  def index
+    @people = Person.all
+  end
+
+  def new
+    @person = Person.new
+  end
+
+  def update
+    @person = Person.find(params[:id])
+
+    if @person.update(person_params)
+      redirect_to(manage_people_path, notice: "Person updated successfully")
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def person_params
+    params
+      .require(:person)
+      .permit(:age, :email, :first_name, :last_name, organization_ids: [])
+  end
+end

--- a/app/views/layouts/manage/managelayout.html.erb
+++ b/app/views/layouts/manage/managelayout.html.erb
@@ -31,10 +31,19 @@
           manage_root_path,
           class: "font-semibold text-lg hover:text-slate-200"
         ) %>
+
         <div class="ml-8 flex gap-6">
           <%= link_to(
             "Organizations",
             manage_organizations_path,
+            class: "hover:text-slate-200"
+          ) %>
+        </div>
+
+        <div class="ml-8 flex gap-6">
+          <%= link_to(
+            "People",
+            manage_people_path,
             class: "hover:text-slate-200"
           ) %>
         </div>

--- a/app/views/manage/organizations/_form.html.erb
+++ b/app/views/manage/organizations/_form.html.erb
@@ -8,7 +8,8 @@
   <% if form_model.errors.any? %>
     <div class="mb-6 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
       <p class="mb-2 font-semibold">
-        <%= pluralize(form_model.errors.count, "error") %> prevented this organization from being saved:
+        <%= pluralize(form_model.errors.count, "error") %>
+        prevented this organization from being saved:
       </p>
       <ul class="list-disc list-inside space-y-1">
         <% form_model.errors.full_messages.each do |message| %>

--- a/app/views/manage/people/_form.html.erb
+++ b/app/views/manage/people/_form.html.erb
@@ -1,0 +1,115 @@
+<%=
+  form_with(
+    data: { turbo: false },
+    model: form_model,
+    url: form_path
+  ) do |form|
+%>
+  <% if form_model.errors.any? %>
+    <div class="mb-6 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
+      <p class="mb-2 font-semibold">
+        <%= pluralize(form_model.errors.count, "error") %>
+        prevented this person from being saved:
+      </p>
+      <ul class="list-disc list-inside space-y-1">
+        <% form_model.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="mt-4 flex items-center gap-3">
+    <%= form.label(
+      :first_name,
+      class: "text-sm font-medium text-slate-700 shrink-0 min-w-[4rem]"
+    ) %>
+    <div class="flex-1 min-w-0">
+      <%= form.text_field(
+        :first_name,
+        class: "input-primary w-full",
+        placeholder: "First Name"
+      ) %>
+      <% if form_model.errors[:first_name].any? %>
+        <p class="mt-1 text-sm text-red-600">
+          <%= form_model.errors[:first_name].first %>
+        </p>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="mt-4 flex items-center gap-3">
+    <%= form.label(
+      :last_name,
+      class: "text-sm font-medium text-slate-700 shrink-0 min-w-[4rem]"
+    ) %>
+    <div class="flex-1 min-w-0">
+      <%= form.text_field(
+        :last_name,
+        class: "input-primary w-full",
+        placeholder: "Last Name"
+      ) %>
+      <% if form_model.errors[:last_name].any? %>
+        <p class="mt-1 text-sm text-red-600">
+          <%= form_model.errors[:last_name].first %>
+        </p>
+      <% end %>
+    </div>
+  </div>
+
+    <div class="mt-4 flex items-center gap-3">
+    <%= form.label(
+      :age,
+      class: "text-sm font-medium text-slate-700 shrink-0 min-w-[4rem]"
+    ) %>
+    <div class="flex-1 min-w-0">
+      <%= form.number_field(
+        :age,
+        class: "input-primary",
+        maximum: 120,
+        minimum: 1,
+        step: 1
+      ) %>
+      <% if form_model.errors[:age].any? %>
+        <p class="mt-1 text-sm text-red-600">
+          <%= form_model.errors[:age].first %>
+        </p>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="mt-4 flex items-center gap-3">
+    <%= form.label(
+      :email,
+      class: "text-sm font-medium text-slate-700 shrink-0 min-w-[4rem]"
+    ) %>
+    <div class="flex-1 min-w-0">
+      <%= form.email_field(:email, class: "input-primary w-full") %>
+      <% if form_model.errors[:email].any? %>
+        <p class="mt-1 text-sm text-red-600">
+          <%= form_model.errors[:email].first %>
+        </p>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="mt-4 flex items-center gap-3">
+    <%= form.label(
+      "Organizations",
+      class: "text-sm font-medium text-slate-700 shrink-0 min-w-[4rem]"
+    ) %>
+
+    <%= form.collection_check_boxes(
+      :organization_ids,
+      Organization.order(:name),
+      :id,
+      :name,
+      { prompt: "Select Organizations" },
+      { class: "block w-full" }
+    ) %>
+  </div>
+
+  <div class="mt-16">
+    <%= form.submit "💾 Save", class: "btn-primary" %>
+  </div>
+<% end %>

--- a/app/views/manage/people/edit.html.erb
+++ b/app/views/manage/people/edit.html.erb
@@ -1,0 +1,17 @@
+<div>
+  <div class="mb-8">
+    <h1 class="text-2xl font-bold">Edit Person</h1>
+  </div>
+
+  <div>
+    <%=
+      render(
+        partial: "form",
+        locals: {
+          form_path: manage_person_path(@person),
+          form_model: @person
+        }
+      )
+    %>
+  </div>
+</div>

--- a/app/views/manage/people/index.html.erb
+++ b/app/views/manage/people/index.html.erb
@@ -1,0 +1,70 @@
+<div class="min-w-0 flex-1">
+  <div class="flex items-center justify-between mb-4">
+    <span>
+      <h1 class="text-2xl font-bold">Manage People</h1>
+    </span>
+
+    <span class="ml-auto">
+      <%= link_to(
+        "📈 New Person",
+        new_manage_person_path,
+        class: "btn-primary"
+      ) %>
+    </span>
+  </div>
+
+  <table class="table-auto border-separate border-spacing-y-2">
+    <thead>
+      <tr>
+        <th class="px-1">Last Name</th>
+        <th class="px-1">First Name</th>
+        <th class="px-1">Age</th>
+        <th class="px-1">Email</th>
+        <th class="px-1">ID</th>
+        <th class="px-1">Created</th>
+        <th class="px-1">Updated</th>
+        <th class="px-1">Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @people.each do |person| %>
+        <tr
+          id="manage-person-row-<%= person.id %>"
+          class="hover:bg-slate-100"
+        >
+          <td class="pr-4 py-2"><%= person.last_name %></td>
+          <td class="pr-4 py-2"><%= person.first_name %></td>
+          <td class="pr-4 py-2"><%= person.age %></td>
+          <td class="pr-4 py-2"><%= person.email %></td>
+          <td class="px-4 py-2"><%= person.id %></td>
+          <td class="px-4 py-2">
+            <%= person.created_at.strftime("%Y-%m-%d %H:%M:%S") %>
+          </td>
+          <td class="px-4 py-2">
+            <%= person.updated_at.strftime("%Y-%m-%d %H:%M:%S") %>
+          </td>
+          <td>
+            <%= link_to(
+              "✍️ Edit",
+              edit_manage_person_path(person),
+              class: "btn-primary px-4 py-2"
+            ) %>
+
+            <%= button_to(
+              "🗑️ Delete",
+              manage_person_path(person),
+              method: :delete,
+              class: "btn-primary px-4 py-2",
+              form_class: "inline-block ml-2",
+              form: {
+                data: {
+                  turbo_confirm: "Are you sure you want to delete this person?"
+                }
+              }
+            ) %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/manage/people/new.html.erb
+++ b/app/views/manage/people/new.html.erb
@@ -1,0 +1,17 @@
+<div>
+  <div class="mb-8">
+    <h1 class="text-2xl font-bold">New Person</h1>
+  </div>
+
+  <div>
+    <%=
+      render(
+        partial: "form",
+        locals: {
+          form_path: manage_people_path,
+          form_model: @person
+        }
+      )
+    %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
 
   namespace(:manage) do
     resources(:organizations, except: [:show])
+    resources(:people, except: [:show])
 
     root(controller: :dashboards, action: :index)
   end

--- a/spec/features/manage/dashboards/admin_views_dashboards_page_spec.rb
+++ b/spec/features/manage/dashboards/admin_views_dashboards_page_spec.rb
@@ -5,5 +5,10 @@ RSpec.feature("An Admin Views Dashboards Page", type: :feature) do
     visit manage_root_url
 
     expect(page).to have_content("Welcome to Fellowship Factory Management")
+
+    within("nav") do
+      expect(page).to have_link("Organizations")
+      expect(page).to have_link("People")
+    end
   end
 end

--- a/spec/features/manage/organizations/admin_creates_organization_spec.rb
+++ b/spec/features/manage/organizations/admin_creates_organization_spec.rb
@@ -18,6 +18,10 @@ RSpec.feature("An Admin Views New Organization Page", type: :feature) do
 
     click_button("💾 Save")
 
-    expect(page).to have_content("")
+    expect(page).to have_content(
+      "1 error prevented this organization from being saved"
+    )
+
+    expect(page).to have_content("Name is too short")
   end
 end

--- a/spec/features/manage/people/admin_creates_person_spec.rb
+++ b/spec/features/manage/people/admin_creates_person_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.feature("An Admin Views New Person Page", type: :feature) do
+  scenario "Creates an Person with Success" do
+    create(:organization, name: "The Zealous Ones")
+
+    visit new_manage_person_path
+
+    fill_in("First Name", with: "Judah")
+    fill_in("Last name", with: "Maccabee")
+    fill_in("Age", with: 33)
+    fill_in("Email", with: "the-hammer@example.com")
+    check("The Zealous Ones", unchecked: true)
+
+    click_button("💾 Save")
+
+    expect(page).to have_content("Person created successfully")
+  end
+
+  scenario "Sees an Error when Creating a Person Fails" do
+    visit new_manage_person_path
+
+    fill_in("First Name", with: "Baruch")
+    fill_in("Last name", with: "the Scribe")
+    fill_in("Age", with: 60)
+    fill_in("Email", with: "📜")
+
+    click_button("💾 Save")
+
+    expect(page).to have_content(
+      "1 error prevented this person from being saved"
+    )
+
+    expect(page).to have_content("Email is invalid")
+  end
+end

--- a/spec/features/manage/people/admin_edits_person_spec.rb
+++ b/spec/features/manage/people/admin_edits_person_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.feature("An Admin Views Edit Person Page", type: :feature) do
+  scenario "Updates an Person with Success" do
+    create(:organization, name: "The Shepherds")
+    person = create(:person)
+
+    visit edit_manage_person_path(person)
+
+    fill_in("First Name", with: "David")
+    fill_in("Last name", with: "Son of Jesse")
+    fill_in("Age", with: 20)
+    fill_in("Email", with: "slayer-of-tens-of-thousands@example.com")
+    check("The Shepherds", unchecked: true)
+
+    click_button("💾 Save")
+
+    expect(page).to have_content("Person updated successfully")
+  end
+
+  scenario "Sees an Error when Updating an Person Fails" do
+    person = create(:person)
+
+    visit edit_manage_person_path(person)
+
+    fill_in("First Name", with: "Enoch")
+    fill_in("Last name", with: "the Scribe")
+    fill_in("Age", with: 365)
+    fill_in("Email", with: "them-watchers-be-wilin@example.com")
+
+    click_button("💾 Save")
+
+    expect(page).to(
+      have_content("1 error prevented this person from being saved")
+    )
+
+    expect(page).to(have_content("Age must be less than 121"))
+  end
+end

--- a/spec/features/manage/people/admin_views_people_spec.rb
+++ b/spec/features/manage/people/admin_views_people_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.feature("An Admin Views People Index Page", type: :feature) do
+  scenario "Landing on People Index" do
+    person_a = create(:person, first_name: "Jashobeam")
+    person_b = create(:person, first_name: "Eleazar")
+
+    visit manage_people_url
+
+    expect(page).to have_content("Manage People")
+    expect(page).to have_link("📈 New Person")
+
+    within("#manage-person-row-#{person_a.id}") do
+      expect(page).to have_content("Jashobeam")
+      expect(page).to have_link("✍️ Edit")
+      expect(page).to have_button("🗑️ Delete")
+    end
+
+    within("#manage-person-row-#{person_b.id}") do
+      expect(page).to have_content("Eleazar")
+      expect(page).to have_link("✍️ Edit")
+      expect(page).to have_button("🗑️ Delete")
+    end
+  end
+
+  scenario "Navigate to New Person" do
+    visit manage_people_url
+
+    click_link("New Person")
+
+    expect(page.current_path).to eq(new_manage_person_path)
+  end
+
+  scenario "Navigating to Edit Person" do
+    person = create(:person)
+
+    visit manage_people_url
+
+    click_link("Edit")
+
+    expect(page.current_path).to eq(edit_manage_person_path(person))
+  end
+
+  scenario "Delete an Person" do
+    create(:person, first_name: "Korah")
+
+    visit manage_people_url
+
+    click_button("Delete")
+
+    expect(page).to have_content("Person deleted successfully")
+    expect(page).not_to have_content("Korah")
+  end
+end


### PR DESCRIPTION
We need more UIs for CRUD ops in /manage.

This changeset introduces CRUD tools for `People`. It also adds a checkbox list for managing the `Person` and `Organization` relationship.

GH #68