### PR TITLE
Create UI for Adding People to Organization

### DIFF
--- a/app/controllers/manage/organizations_controller.rb
+++ b/app/controllers/manage/organizations_controller.rb
@@ -56,6 +56,8 @@ class Manage::OrganizationsController < Manage::ManageController
   private
 
   def organization_params
-    params.require(:organization).permit(:name)
+    params.require(:organization).permit(:name, person_ids: [])
+    # 🚧 TODO
+    # params.expect(organization: [:name, people_ids: []])
   end
 end

--- a/app/views/manage/organizations/_form.html.erb
+++ b/app/views/manage/organizations/_form.html.erb
@@ -38,6 +38,22 @@
     </div>
   </div>
 
+  <div class="mt-4 flex items-center gap-3">
+    <%= form.label(
+      "People",
+      class: "text-sm font-medium text-slate-700 shrink-0 min-w-[4rem]"
+    ) %>
+
+    <%= form.collection_checkboxes(
+      :person_ids,
+      Person.order(:last_name),
+      :id,
+      :last_name,
+      {},
+      { class: "block" }
+    ) %>
+  </div>
+
   <div class="mt-16">
     <%= form.submit "💾 Save", class: "btn-primary" %>
   </div>

--- a/spec/features/manage/organizations/admin_creates_organization_spec.rb
+++ b/spec/features/manage/organizations/admin_creates_organization_spec.rb
@@ -2,9 +2,12 @@ require "rails_helper"
 
 RSpec.feature("An Admin Views New Organization Page", type: :feature) do
   scenario "Creates an Organization with Success" do
+    create(:person, first_name: "King", last_name: "Hezekiah")
+
     visit new_manage_organization_path
 
     fill_in("Name", with: "Prophets of the Promise")
+    check("Hezekiah")
 
     click_button("💾 Save")
 


### PR DESCRIPTION
We can add an `Organization` to a `Person`.

This changeset adds UI to allow `People` to be associated with an `Organization`.

GH #69