### PR TITLE
Add Modal Overlay Card to List People's Organizations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,4 +36,5 @@ group :test do
   gem "rspec-rails", "~> 8.0"
   gem "selenium-webdriver"
   gem "shoulda-matchers", "~> 7.0"
+  # gem "webdrivers" # updates so slow, it fails when new chromedriver released!
 end

--- a/app/controllers/manage/people_controller.rb
+++ b/app/controllers/manage/people_controller.rb
@@ -27,6 +27,12 @@ class Manage::PeopleController < Manage::ManageController
     @people = Person.all
   end
 
+  def list_organizations
+    @person = Person.includes(:organizations).find(params[:id])
+
+    render(partial: "organizations_card", locals: {person: @person})
+  end
+
   def new
     @person = Person.new
   end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,4 +1,5 @@
-// Import and register all your controllers from the importmap via controllers/**/*_controller
+// Import and register all your controllers from the
+//  importmap via controllers/**/*_controller
 import { application } from "controllers/application"
 import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
 eagerLoadControllersFrom("controllers", application)

--- a/app/javascript/controllers/manage/people_index_overlay_controller.js
+++ b/app/javascript/controllers/manage/people_index_overlay_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  close(event) {
+    event.preventDefault()
+
+    const frame = this.element.closest("turbo-frame")
+
+    if (frame) {
+      frame.innerHTML = ""
+    }
+  }
+}

--- a/app/views/manage/people/_organizations_card.html.erb
+++ b/app/views/manage/people/_organizations_card.html.erb
@@ -1,0 +1,29 @@
+<turbo-frame id="person-organizations-overlay">
+  <div
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+    data-controller="overlay"
+  >
+    <div class="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+      <div class="mb-4 flex items-center justify-between">
+        <h2 class="text-lg font-semibold">
+          Organizations for
+          <%= person.first_name %> <%= person.last_name %>
+        </h2>
+
+        <a
+          href="#"
+          data-action="click->overlay#close"
+          class="text-slate-500 hover:text-slate-700"
+        >✖️</a>
+      </div>
+
+      <ul class="space-y-2">
+        <% person.organizations.each do |organization| %>
+          <li class="rounded border border-blue-500 px-3 py-2">
+            <div class="font-medium"><%= organization.name %></div>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+</turbo-frame>

--- a/app/views/manage/people/index.html.erb
+++ b/app/views/manage/people/index.html.erb
@@ -21,6 +21,7 @@
         <th class="px-1">Age</th>
         <th class="px-1">Email</th>
         <th class="px-1">ID</th>
+        <th class="px-1">Organizations</th>
         <th class="px-1">Created</th>
         <th class="px-1">Updated</th>
         <th class="px-1">Actions</th>
@@ -37,6 +38,18 @@
           <td class="pr-4 py-2"><%= person.age %></td>
           <td class="pr-4 py-2"><%= person.email %></td>
           <td class="px-4 py-2"><%= person.id %></td>
+          <td class="px-4 py-2">
+            <% if person.organizations.present? %>
+              <%= link_to(
+                "Organizations",
+                list_organizations_manage_person_path(person),
+                data: {turbo_frame: "person-organizations-overlay"},
+                class: "text-blue-600 hover:text-blue-800 underline"
+              ) %>
+            <% else %>
+              None
+            <% end %>
+          </td>
           <td class="px-4 py-2">
             <%= person.created_at.strftime("%Y-%m-%d %H:%M:%S") %>
           </td>
@@ -67,4 +80,6 @@
       <% end %>
     </tbody>
   </table>
+
+  <turbo-frame id="person-organizations-overlay"></turbo-frame>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,12 @@ Rails.application.routes.draw do
 
   namespace(:manage) do
     resources(:organizations, except: [:show])
-    resources(:people, except: [:show])
+
+    resources(:people, except: [:show]) do
+      member do
+        get :list_organizations
+      end
+    end
 
     root(controller: :dashboards, action: :index)
   end

--- a/spec/features/manage/people/admin_views_people_spec.rb
+++ b/spec/features/manage/people/admin_views_people_spec.rb
@@ -2,8 +2,12 @@ require "rails_helper"
 
 RSpec.feature("An Admin Views People Index Page", type: :feature) do
   scenario "Landing on People Index" do
-    person_a = create(:person, first_name: "Jashobeam")
-    person_b = create(:person, first_name: "Eleazar")
+    organization = create(:organization, name: "The Three")
+
+    person_a =
+      create(:person, first_name: "Jashobeam", organizations: [organization])
+
+    person_b = create(:person, first_name: "Abishai")
 
     visit manage_people_url
 
@@ -12,15 +16,40 @@ RSpec.feature("An Admin Views People Index Page", type: :feature) do
 
     within("#manage-person-row-#{person_a.id}") do
       expect(page).to have_content("Jashobeam")
+      expect(page).to have_link("Organizations")
       expect(page).to have_link("✍️ Edit")
       expect(page).to have_button("🗑️ Delete")
     end
 
     within("#manage-person-row-#{person_b.id}") do
-      expect(page).to have_content("Eleazar")
+      expect(page).to have_content("Abishai")
+      expect(page).to have_content("None")
       expect(page).to have_link("✍️ Edit")
       expect(page).to have_button("🗑️ Delete")
     end
+  end
+
+  scenario("Views Organizations List", js: true) do
+    organization = create(:organization, name: "Major Prophets")
+
+    person =
+      create(:person, first_name: "Isaiah", organizations: [organization])
+
+    visit manage_people_path
+
+    within("#manage-person-row-#{person.id}") do
+      click_link("Organizations")
+    end
+
+    within("#person-organizations-overlay") do
+      expect(page).to have_content("Organizations for Isaiah")
+      expect(page).to have_content("Major Prophets")
+
+      click_link("✖️")
+    end
+
+    expect(page).not_to have_content("Organizations for Isaiah")
+    expect(page).not_to have_content("Major Prophets")
   end
 
   scenario "Navigate to New Person" do

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,1 +1,20 @@
 require "capybara/rspec"
+require "selenium-webdriver"
+
+Capybara.register_driver :selenium_chrome do |app|
+  Capybara::Selenium::Driver.new(app, browser: :chrome)
+end
+
+Capybara.register_driver :selenium_chrome_headless do |app|
+  options = Selenium::WebDriver::Chrome::Options.new
+
+  options.add_argument("--headless")
+  options.add_argument("--disable-gpu")
+  options.add_argument("--no-sandbox")
+  # options.add_argument("--window-size=1400,1400")
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+end
+
+Capybara.default_driver = :rack_test
+Capybara.javascript_driver = :selenium_chrome_headless


### PR DESCRIPTION
We want a convenient way to list the `Organization` associations for a `Person` in the list in Manage. We also want an excuse to start using Hotwire!

This changeset adds a link in the `People` table in `/manage` that will display a small card listing `Organizations` when clicked. This changeset also introduces headless web browser integration for feature specs. It also includes the first Stimulus controller and Hotwire'd view partial.

GH #73